### PR TITLE
Restore the behavior of remembering the CWD fd in the parser

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -210,6 +210,11 @@ completion_list_t parser_t::expand_argument_list(const wcstring &arg_list_src,
     return result;
 }
 
+void parser_t::set_cwd_fd(int fd) {
+    assert(fd >= 0 && "Invalid fd");
+    this->libdata().cwd_fd = std::make_shared<autoclose_fd_t>(fd);
+}
+
 std::shared_ptr<parser_t> parser_t::shared() { return shared_from_this(); }
 
 cancel_checker_t parser_t::cancel_checker() const {

--- a/src/parser.h
+++ b/src/parser.h
@@ -487,6 +487,10 @@ class parser_t : public std::enable_shared_from_this<parser_t> {
     /// Mark whether we should sync universal variables.
     void set_syncs_uvars(bool flag) { syncs_uvars_ = flag; }
 
+    /// Set the given file descriptor as the working directory for this parser.
+    /// This acquires ownership.
+    void set_cwd_fd(int fd);
+
     /// \return a shared pointer reference to this parser.
     std::shared_ptr<parser_t> shared();
 


### PR DESCRIPTION
This will be important for concurrent execution, because different parsers will have different working directories.

